### PR TITLE
Add coverage to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ client/.pnp
 client/.pnp.js
 
 # testing
+coverage
 client/coverage
 
 # production


### PR DESCRIPTION
When running jest --coverage, gitignore now has coverage so that the coverage folder won't be pushed to github.